### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
  Description:  bootScore Child Theme
  Author:       bootScore
  Author URI:   https://bootscore.me
- Template:     bootscore-main
+ Template:     bootscore
  Version:      5.3.0
  Text Domain:  bootscore
 */


### PR DESCRIPTION
Wrong Template referenced. Child theme would not appear in Themes browser. This change fixes that.

Update: I installed all of the packages via composer and the child template did not appear in the theme browser. The browser stated 'The parent theme is missing. Please install the "bootscore-main" parent theme.' . After changing this value it did appear. The Metatdata theme name in the "bootscore/style.css" file is "bootscore" not "bootscore-main" hence I assume it fails.